### PR TITLE
Add validation for nil response

### DIFF
--- a/http.go
+++ b/http.go
@@ -29,9 +29,11 @@ type ErrorType struct {
 // WriteJSONResponse write to te response stream
 func WriteJSONResponse(w http.ResponseWriter, response *Response) {
 	header := w.Header()
-	for key, values := range response.Headers {
-		for _, value := range values {
-			header.Add(key, value)
+	if response != nil {
+		for key, values := range response.Headers {
+			for _, value := range values {
+				header.Add(key, value)
+			}
 		}
 	}
 	header.Set("Content-Type", "application/json")


### PR DESCRIPTION
- This happens when the http server does not respond to the request,
  then we have a nil response object and then response.Headers is processed as nil.Headers,
  so a beautiful panic is born